### PR TITLE
Fix/number parser 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "./module/messenger/*": "./dist/module/messenger/*.js"
   },
   "name": "bot-express",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": false,
   "repository": {
     "type": "git",

--- a/src/module/parser/number.js
+++ b/src/module/parser/number.js
@@ -60,14 +60,14 @@ module.exports = class ParserNumber {
             }
         }
 
-        if (policy.min){
+        if (policy.min != null){
             if (parsed_value < policy.min){
                 throw new Error("be_parser__too_small");
             }
         }
 
-        if (policy.max){
-            if (parsed_value> policy.max){
+        if (policy.max != null){
+            if (parsed_value > policy.max){
                 throw new Error("be_parser__too_large");
             }
         }

--- a/src/test/builtin-parser-number.js
+++ b/src/test/builtin-parser-number.js
@@ -15,7 +15,9 @@ const emu = new Emulator(messenger_option.name, messenger_option.options);
 
 chai.use(chaiAsPromised);
 const should = chai.should();
-const user_id = "dummy_user_id";
+const user_d = "dummy_user_id";
+const ParserNumber = require("../module/parser/number")
+const parser = new ParserNumber()
 
 describe("Test builtin number parser", async function(){
 
@@ -190,4 +192,28 @@ describe("Test builtin number parser", async function(){
             context.confirming.should.equal("no_policy");
         });
     });
+
+    describe("0 as max and provide 1", async function(){
+        it("will be rejected.", async function(){
+            let e_message
+            try {
+                await parser.parse(1, { max: 0 })
+            } catch(e){
+                e_message = e.message
+            }
+            e_message.should.equal("be_parser__too_large")
+        })
+    })
+
+    describe("0 as min and provide -1", async function(){
+        it("will be rejected.", async function(){
+            let e_message
+            try {
+                await parser.parse(-1, { min: 0 })
+            } catch(e){
+                e_message = e.message
+            }
+            e_message.should.equal("be_parser__too_small")
+        })
+    })
 });

--- a/src/test/builtin-parser-number.js
+++ b/src/test/builtin-parser-number.js
@@ -15,7 +15,7 @@ const emu = new Emulator(messenger_option.name, messenger_option.options);
 
 chai.use(chaiAsPromised);
 const should = chai.should();
-const user_d = "dummy_user_id";
+const user_id = "dummy_user_id";
 const ParserNumber = require("../module/parser/number")
 const parser = new ParserNumber()
 


### PR DESCRIPTION
数値のビルトインパーサーでpolicyのmin, maxの値が0の場合に判定されない問題を修正しました。