### PR TITLE
Fix/email parser whitespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bot-express",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -871,6 +871,21 @@
         }
       }
     },
+    "@types/chai": {
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
+      "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
+      "dev": true
+    },
+    "@types/chai-as-promised": {
+      "version": "7.1.8",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz",
+      "integrity": "sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -1017,6 +1032,12 @@
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "optional": true
+    },
+    "@types/mocha": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
+      "dev": true
     },
     "@types/node": {
       "version": "18.16.18",

--- a/package.json
+++ b/package.json
@@ -52,9 +52,12 @@
     "wanakana": "^4.0.2"
   },
   "devDependencies": {
+    "@types/chai": "^4.3.11",
+    "@types/chai-as-promised": "^7.1.8",
     "@types/cookie": "^0.5.1",
     "@types/cookie-parser": "^1.4.3",
     "@types/express": "^4.17.17",
+    "@types/mocha": "^10.0.6",
     "@types/node": "^18.16.18",
     "@types/ws": "^8.5.4",
     "@typescript-eslint/eslint-plugin": "^5.59.7",

--- a/src/module/parser/email.js
+++ b/src/module/parser/email.js
@@ -39,7 +39,7 @@ module.exports = class ParserEmail {
             throw new Error(`be_parser__should_be_string`)
         }
 
-        const regex = new RegExp(/^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$/)
+        const regex = new RegExp(/^[a-zA-Z0-9_+-]+(\.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$/)
         if (!value.match(regex)){
             throw new Error(`be_parser__should_be_email_format`)
         }

--- a/src/test/builtin-parser-email.ts
+++ b/src/test/builtin-parser-email.ts
@@ -2,20 +2,22 @@
 
 require("dotenv").config();
 
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
-const Emulator = require("../test-util/emulator");
-const messenger_option = {
-    name: "line",
-    options: {
-        line_channel_secret: process.env.LINE_CHANNEL_SECRET
-    }
-};
-const emu = new Emulator(messenger_option.name, messenger_option.options);
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import Emulator from "../test-util/emulator";
 
 chai.use(chaiAsPromised);
 const should = chai.should();
 const user_id = "dummy_user_id";
+
+const messenger_option = {
+    name: "line",
+    options: {
+        line_channel_secret: process.env.LINE_CHANNEL_SECRET,
+    }
+};
+const emu = new Emulator(messenger_option.name, messenger_option.options, user_id);
+
 
 describe("Test builtin email parser", async function(){
 
@@ -65,6 +67,30 @@ describe("Test builtin email parser", async function(){
             context.confirming.should.equal("email");
 
             context = await emu.send(emu.create_message_event(user_id, "nkjm.kzk.gmail.com"));
+
+            // Test
+            should.not.exist(context.confirmed.email);
+        });
+
+        it("will be rejected because of white space.", async function(){
+            this.timeout(15000);
+
+            await emu.clear_context(user_id);
+            
+            let event = emu.create_postback_event(user_id, {data: JSON.stringify({
+                _type: "intent",
+                language: "ja",
+                intent: {
+                    name: "test-builtin-parser-email"
+                }
+            })});
+            let context = await emu.send(event);
+
+            // Test
+            context.intent.name.should.equal("test-builtin-parser-email");
+            context.confirming.should.equal("email");
+
+            context = await emu.send(emu.create_message_event(user_id, "nkjm kzk@gmail.com"));
 
             // Test
             should.not.exist(context.confirmed.email);


### PR DESCRIPTION
Emailのビルトインパーサーでアカウントに空白が入った場合にエラー判定されない問題を修正しました。