### PR TITLE
Feature/dynamic sub parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bot-express",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "./module/messenger/*": "./dist/module/messenger/*.js"
   },
   "name": "bot-express",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "private": false,
   "repository": {
     "type": "git",

--- a/src/sample_parameter/parameter.js
+++ b/src/sample_parameter/parameter.js
@@ -73,7 +73,7 @@ module.exports = class Parameter {
                     throw new Error("invalid_type");
                 }
                 let phone = value.replace(/[\B-]/g, "");
-                if (!zip_code.match(/^[0-9]{11}$/)){
+                if (!phone.match(/^[0-9]{11}$/)){
                     throw new Error("violates_regex");
                 }
                 return phone;
@@ -81,6 +81,37 @@ module.exports = class Parameter {
         }
         if (o.condition) param.condition = o.condition
         if (o.reaction) param.reaction = o.reaction
+        return param
+    }
+
+    contact_list() {
+        const param = {
+            list: {
+                order: "old"
+            },
+            sub_parameter: {
+                "phone": {
+                    generator: {
+                        file: "parameter",
+                        method: "phone",
+                        options: {
+                            message_text: "電話番号をお願いします。"
+                        }
+                    }
+                },
+                "zip_code": {
+                    generator: {
+                        file: "parameter",
+                        method: "zip_code",
+                        options: {
+                            message_text: "郵便番号をお願いします。"
+                        }
+                    }
+                },
+
+            }
+        } 
+
         return param
     }
 }

--- a/src/sample_skill/test-generating-sub-parameter.js
+++ b/src/sample_skill/test-generating-sub-parameter.js
@@ -1,0 +1,21 @@
+"use strict"
+
+module.exports = class SkillTestGeneratingSubParameter {
+    constructor(){
+    }
+
+    async begin(bot, event, context){
+        bot.collect_by_generator("contact_list", {
+            file: "parameter",
+            method: "contact_list",
+            options: null
+        })
+    }
+
+    async finish(bot, event, context){
+        await bot.reply({
+            type: "text",
+            text: `phone: ${context.confirmed.contact_list[0].phone}, zip_code: ${context.confirmed.contact_list[0].zip_code}`
+        })
+    }
+}

--- a/src/test/generating-sub-parameter.ts
+++ b/src/test/generating-sub-parameter.ts
@@ -1,0 +1,49 @@
+"use strict";
+
+require("dotenv").config();
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import Emulator from "../test-util/emulator";
+
+chai.use(chaiAsPromised);
+const should = chai.should();
+const user_id = "dummy_user_id";
+
+const messenger_option = {
+    name: "line",
+    options: {
+        line_channel_secret: process.env.LINE_CHANNEL_SECRET,
+    }
+};
+const emu = new Emulator(messenger_option.name, messenger_option.options, user_id);
+
+
+describe.only("Test generating sub parameter", async function(){
+
+    describe("Enter 1 record", async function(){
+        it("will be stored in list parameter.", async function(){
+            this.timeout(15000);
+
+            await emu.clear_context(user_id);
+            
+            let event = emu.create_postback_event(user_id, {data: JSON.stringify({
+                type: "intent",
+                intent: {
+                    name: "test-generating-sub-parameter"
+                }
+            })});
+            let context = await emu.send(event);
+
+            context.intent.name.should.equal("test-generating-sub-parameter");
+            context.confirming.should.equal("phone");
+            context = await emu.send(emu.create_message_event(user_id, "09011223344"));
+
+            context.confirming.should.equal("zip_code");
+            context = await emu.send(emu.create_message_event(user_id, "1070062"));
+
+            should.not.exist(context.confirming)
+            context.previous.message[0].message.text.should.equal(`phone: 09011223344, zip_code: 1070062`)
+        });
+    });
+});


### PR DESCRIPTION
ものすごく深い部分の修正です。
bot-expressではbot.collect()を使って静的に定義されたパラメーターをcontext.to_confirmに追加することができます。このバリエーションとして、bot.collect_by_generator()を使うことで、動的に生成したパラメーターオブジェクトをcontext.to_confirmに追加することができます。ただし、このパターンで追加した場合、中にsub_parameterがあるとうまく動きませんでした。bot.get_parameter()でパラメーターを取得するときに、該当パラメーターがみつからない、という状態になっていました。この部分を修正して、動的に追加したパラメーター内でもsub_parameterが機能するようにしています。