### PR TITLE
Hot fix/modify previous at list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bot-express",
-  "version": "0.9.18",
+  "version": "0.9.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "./module/messenger/*": "./dist/module/messenger/*.js"
   },
   "name": "bot-express",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "private": false,
   "repository": {
     "type": "git",

--- a/src/module/bot.js
+++ b/src/module/bot.js
@@ -1030,6 +1030,7 @@ class Bot {
         Object.assign(this._context.heard, collected_heard)
         Object.assign(this._context.global, global)
         Object.assign(this._context._message_queue, message_queue)
+        Object.assign(this._context.previous.processed, parent_context.previous.processed)
     }
 
     /**

--- a/src/module/bot.js
+++ b/src/module/bot.js
@@ -775,15 +775,15 @@ class Bot {
      * @param {Boolean} [options.clear_confirmed]
      */
     rewind_confirmed(options = {}){
+        // If we're in sub parameter and collect first child question, we need to go back to previous parameter.
+        if (this._context._sub_parameter && Object.keys(this._context.confirmed).length === 0) {
+            this.checkout_parent_parameter()
+        }
+
         // Check if there is previously processed parameter.
         if (!(this._context.previous && Array.isArray(this._context.previous.processed) && this._context.previous.processed.length > 0)){
             debug(`There is no processed parameter.`);
             return;
-        }
-
-        // If we're in sub parameter and collect first child question, we need to go back to previous parameter.
-        if (this._context._sub_parameter && Object.keys(this._context.confirmed).length === 0) {
-            this.checkout_parent_parameter()
         }
 
         const param_name = this._context.previous.processed[0];

--- a/src/module/flow.js
+++ b/src/module/flow.js
@@ -958,6 +958,7 @@ module.exports = class Flow {
         this.context.to_confirm = Object.keys(param.sub_parameter)
         // Clear confirmed.
         this.context.confirmed = {}
+        this.context.previous.processed = []
         // Set parent information.
         this.context._parent_parameter = {
             type: param.type,


### PR DESCRIPTION
sub parameterにてparent parameterと同一の項目をヒアリングしているケースにおいて、rewind_confirmedを実施するとエラーになる問題へ対応しました。

対応したのは以下
- module/flow.js/checkout_sub_parameterにてparent parameter同一階層でヒアリングした内容のワイプ
- module/bot.js/checkout_parent_parameterにてsub parameter前にヒアリングした内容を戻す
- rewind_confirmedにて、#53 で実装したロールバック処理を最初に行うように変更
