### PR TITLE
Retry with ECONN

### DIFF
--- a/src/module/messenger/line.js
+++ b/src/module/messenger/line.js
@@ -449,11 +449,9 @@ module.exports = class MessengerLine {
     }
 
     static is_monthly_limit(e){
-        debug(`Check if following error is due to monthly limit.`)
         if(!e.response || !e.response.data){
             return false;
         }
-        debug(e.response.data)
 
         if (e.response.data.details){
             if (e.response.data.details.find((d) => d.message.includes(`You have reached your monthly limit`))){

--- a/src/module/messenger/line.js
+++ b/src/module/messenger/line.js
@@ -346,7 +346,8 @@ module.exports = class MessengerLine {
 
         let url = `https://${this._endpoint}/${this._api_version}/bot/message/broadcast`;
         let headers = {
-            Authorization: `Bearer ${this._access_token}`
+            Authorization: `Bearer ${this._access_token}`,
+            'X-Line-Retry-Key': this.generate_retry_key(),
         }
         let body = {
             messages: messages
@@ -377,7 +378,8 @@ module.exports = class MessengerLine {
         
         let url = `https://${this._endpoint}/${this._api_version}/bot/message/multicast`;
         let headers = {
-            Authorization: `Bearer ${this._access_token}`
+            Authorization: `Bearer ${this._access_token}`,
+            'X-Line-Retry-Key': this.generate_retry_key(),
         }
         let body = {
             to: to,
@@ -409,7 +411,8 @@ module.exports = class MessengerLine {
 
         let url = `https://${this._endpoint}/${this._api_version}/bot/message/push`;
         let headers = {
-            Authorization: `Bearer ${this._access_token}`
+            Authorization: `Bearer ${this._access_token}`,
+            'X-Line-Retry-Key': this.generate_retry_key(),
         }
         let body = {
             to: to,
@@ -498,7 +501,7 @@ module.exports = class MessengerLine {
 
         let url = `https://${this._endpoint}/${this._api_version}/bot/message/reply`;
         let headers = {
-            Authorization: `Bearer ${this._access_token}`
+            Authorization: `Bearer ${this._access_token}`,
         }
         let body = {
             replyToken: event.replyToken,
@@ -570,6 +573,11 @@ module.exports = class MessengerLine {
 
     static extract_to_id(event){
         return event.to[`${event.to.type}Id`];
+    }
+
+    generate_retry_key(){
+        // generate hexadecimal UUID
+        return crypto.randomBytes(36).toString('hex');
     }
 
     static extract_param_value(event){
@@ -1136,9 +1144,9 @@ module.exports = class MessengerLine {
                 // If this is an error due to Rate Limit, we retry just once.
                 if (e.response.status === 429 && retry == true) {
                     debug(`Got error due to Rate Limit and going to retry..`);
-                    // sleep and retry with
+                    // sleep and retry with only once.
                     await this.sleep();
-                    return this.request(options, false, retry_count + 1);
+                    return this.request(options, false);
 
                 }
                 if (e.response.status === 500 && retry == true) {

--- a/src/module/messenger/line.js
+++ b/src/module/messenger/line.js
@@ -1142,14 +1142,14 @@ module.exports = class MessengerLine {
                     return this.request(options, false);
                 }
                 // If this is an error due to Rate Limit, we retry just once.
-                if (e.response.status === 429 && retry == true) {
+                if (e.response.status === 429 && retry === true) {
                     debug(`Got error due to Rate Limit and going to retry..`);
                     // sleep and retry with only once.
                     await this.sleep();
                     return this.request(options, false);
 
                 }
-                if (e.response.status === 500 && retry == true) {
+                if (e.response.status === 500 && retry === true) {
                     debug(`Got internal server error and going to retry..`);
                     // sleep and retry with incremented retry_count until max_retry
                     await this.sleep();

--- a/src/module/messenger/line.js
+++ b/src/module/messenger/line.js
@@ -1083,83 +1083,89 @@ module.exports = class MessengerLine {
         }
     }
 
-    async request(options, retry = true){
-        options.timeout = 7000
-
+    async sleep() {
+        // Wait for 3000 ms by default.
+        const retry_delay = parseInt(process.env.LINE_RETRY_DELAY) || 3000;
+        const _sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+        await _sleep(retry_delay);
+    }
+    async request(options, retry = true, retry_count = 1) {
+        const max_retry = 3;
+        options.timeout = 7000;
         let response = await axios.request(options).catch(async (e) => {
-            if (e.response){
+            if (e.code) {
+                if( (e.code === 'ECONNRESET' || e.code === 'ECONNREFUSED' || e.code === 'ETIMEDOUT') && retry === true) {
+                    debug(`Got error due to network issue and going to retry (reason: ${e.code})..`);
+                    // sleep and retry with incremented retry_count until max_retry
+                    await this.sleep();
+                    return this.request(options, max_retry > retry_count, retry_count + 1);
+                }
+            }
+            if (e.response) {
                 // If this is an error due to expiration of channel access token, we refresh and retry.
-                if (e.response.status === 401 && retry === true){
-                    debug(`Going to refresh channel access token and retry..`)
-                    await this.refresh_token(true)
+                if (e.response.status === 401 && retry === true) {
+                    debug(`Going to refresh channel access token and retry..`);
+                    await this.refresh_token(true);
                     options.headers = {
                         Authorization: `Bearer ${this._access_token}`
-                    }
-                    return this.request(options, false)
+                    };
+                    return this.request(options, false);
                 }
-
                 // If this is an error due to Rate Limit, we retry just once.
-                if (e.response.status === 429 && retry == true){
-                    debug(`Got error due to Rate Limit and going to retry..`)
+                if (e.response.status === 429 && retry == true) {
+                    debug(`Got error due to Rate Limit and going to retry..`);
+                    // sleep and retry with incremented retry_count until max_retry
+                    await this.sleep();
+                    return this.request(options, max_retry > retry_count, retry_count + 1);
 
-                    // Wait for 3000 ms by default.
-                    const retry_delay = parseInt(process.env.LINE_RETRY_DELAY) || 3000
-                    const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
-                    await sleep(retry_delay)
-
-                    // Retry.
-                    return this.request(options, false)
                 }
-
-                if (e.response.status === 500 && retry == true){
-                    debug(`Got internal server error and going to retry..`)
-
-                    // Wait for 1000 ms by default.
-                    const retry_delay = parseInt(process.env.LINE_RETRY_DELAY) || 1000
-                    const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
-                    await sleep(retry_delay)
-
-                    // Retry.
-                    return this.request(options, false)
+                if (e.response.status === 500 && retry == true) {
+                    debug(`Got internal server error and going to retry..`);
+                    // sleep and retry with incremented retry_count until max_retry
+                    await this.sleep();
+                    return this.request(options, max_retry > retry_count, retry_count + 1);
                 }
-
-                debug(`Error response follows.`)
-                debug(e.response)
-
+                debug(`Error response follows.`);
+                debug(e.response);
                 throw new BotExpressMessengerLineError({
                     message: `Callout failed in messenger/line.js.`,
                     status: e.response.status,
                     request: options,
                     data: e.response.data
-                })                
-            } else if (e.request){
-                if (retry){
-                    debug(`Retry requesting LINE Messaging API..`)
-
+                });
+            }
+            else if (e.request) {
+                if (retry) {
+                    debug(`Retry requesting LINE Messaging API..`);
                     // Retry.
-                    return this.request(options, false)
-                } else {
-                    let error_message = `Callout failed in messenger/line.js. No response received.`
-                    if (options.url) error_message += ` url: ${options.url}`
-                    if (options.data) error_message += ` data: ${JSON.stringify(options.data)}`
+                    return this.request(options, false);
+                }
+                else {
+                    let error_message = `Callout failed in messenger/line.js. No response received.`;
+                    if (options.url)
+                        error_message += ` url: ${options.url}`;
+                    if (options.data)
+                        error_message += ` data: ${JSON.stringify(options.data)}`;
                     throw new BotExpressMessengerLineError({
                         message: error_message
-                    })
+                    });
                 }
-            } else {
-                let error_message = `Callout failed in messenger/line.js.`
-                if (e && e.message){
-                    error_message += ` ${e.message}`
+            }
+            else {
+                let error_message = `Callout failed in messenger/line.js.`;
+                if (e && e.message) {
+                    error_message += ` ${e.message}`;
                 }
-                if (options.url) error_message += ` url: ${options.url}`
-                if (options.data) error_message += ` data: ${JSON.stringify(options.data)}`
+                if (options.url)
+                    error_message += ` url: ${options.url}`;
+                if (options.data)
+                    error_message += ` data: ${JSON.stringify(options.data)}`;
                 throw new BotExpressMessengerLineError({
                     message: error_message
-                })
+                });
             }
-        })
-
-        return response.data
+        });
+        return response.data;
     }
 
     /**

--- a/src/test/econ-retry.js
+++ b/src/test/econ-retry.js
@@ -49,11 +49,15 @@ describe('Test for retry with ECONNRESET', async function () {
 			channel_access_token: 'dummy',
 			endpoint: `http://localhost:${port}`,
 		});
-		try {
+        let headers = {
+            Authorization: `Bearer test`,
+            'X-Line-Retry-Key': line.generate_retry_key(),
+        }
+        try {
 			const ret = await line.request({
 				method: 'post',
 				url: `http://localhost:${port}/v2/bot/message/reply`,
-				headers: '',
+				headers: headers,
 				data: 'test',
 			});
 			console.log(ret);
@@ -70,10 +74,14 @@ describe('Test for retry with ECONNRESET', async function () {
 			endpoint: `http://localhost:${port}`,
 		});
 		try {
-			const ret = await line.request({
+            let headers = {
+                Authorization: `Bearer test`,
+                'X-Line-Retry-Key': line.generate_retry_key(),
+            }
+            const ret = await line.request({
 				method: 'post',
 				url: `http://localhost:${port}/v2/bot/message/multicast`,
-				headers: '',
+				headers: headers,
 				data: 'test',
 			});
 			console.log(ret);

--- a/src/test/econ-retry.js
+++ b/src/test/econ-retry.js
@@ -11,6 +11,7 @@ chai.use(chaiAsPromised);
 const should = chai.should();
 
 const server = http.createServer((req, res) => {
+    console.log(req);
 	// Reproduction ECONNRESET
 	res.socket.end();
 });

--- a/src/test/econ-retry.js
+++ b/src/test/econ-retry.js
@@ -38,7 +38,8 @@ describe('Test for retry with ECONNRESET', async function () {
 			});
 			console.log(ret);
 		} catch (e) {
-			console.log(e);
-		}
+            console.log(e.toString());
+            e.toString().should.includes("BotExpressMessengerLineError");
+        }
 	});
 });

--- a/src/test/econ-retry.js
+++ b/src/test/econ-retry.js
@@ -1,0 +1,44 @@
+'use strict';
+
+require('dotenv').config();
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const MessengerLine = require('../module/messenger/line');
+const http = require('http');
+
+chai.use(chaiAsPromised);
+const should = chai.should();
+
+const server = http.createServer((req, res) => {
+	// Reproduction ECONNRESET
+	res.socket.end();
+});
+
+const port = 3000;
+
+server.listen(port, () => {
+	console.log(`Server running at http://localhost:${port}/`);
+});
+
+describe('Test for retry with ECONNRESET', async function () {
+	it('will retry 3 times with ECONNRESET error.', async function () {
+		const line = new MessengerLine({
+			channel_id: 'dummy',
+			channel_secret: 'dummy',
+			channel_access_token: 'dummy',
+			endpoint: `http://localhost:${port}`,
+		});
+		try {
+			const ret = await line.request({
+				method: 'post',
+				url: `http://localhost:${port}/v2/bot/message/multicast`,
+				headers: '',
+				data: 'test',
+			});
+			console.log(ret);
+		} catch (e) {
+			console.log(e);
+		}
+	});
+});

--- a/src/test/econ-retry.js
+++ b/src/test/econ-retry.js
@@ -5,25 +5,64 @@ require('dotenv').config();
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const MessengerLine = require('../module/messenger/line');
-const http = require('http');
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const server = express();
+server.use(bodyParser.json());
+
+const port = 3000;
 
 chai.use(chaiAsPromised);
 const should = chai.should();
 
-const server = http.createServer((req, res) => {
-    console.log(req);
-	// Reproduction ECONNRESET
-	res.socket.end();
+server.post('/v2/bot/message/multicast', (req, res) => {
+    // Reproduction ECONNRESET
+    res.socket.end();
 });
 
-const port = 3000;
+server.post('/v2/bot/message/reply', (req, res) => {
+    res.status(400).json({
+        message: "The request body has 2 error(s)",
+        details: [
+            {
+                message: "May not be empty",
+                property: "test",
+            },
+            {
+                message: "You have reached your monthly limit.",
+                property: "test",
+            }
+        ]
+    });
+});
 
 server.listen(port, () => {
-	console.log(`Server running at http://localhost:${port}/`);
+    console.log(`Server is listening at http://localhost:${port}`);
 });
 
 describe('Test for retry with ECONNRESET', async function () {
-	it('will retry 3 times with ECONNRESET error.', async function () {
+	it('will not retry with reached monthy limit error.', async function () {
+		const line = new MessengerLine({
+			channel_id: 'dummy',
+			channel_secret: 'dummy',
+			channel_access_token: 'dummy',
+			endpoint: `http://localhost:${port}`,
+		});
+		try {
+			const ret = await line.request({
+				method: 'post',
+				url: `http://localhost:${port}/v2/bot/message/reply`,
+				headers: '',
+				data: 'test',
+			});
+			console.log(ret);
+		} catch (e) {
+            console.log(e.toString());
+            e.toString().should.includes("BotExpressMessengerLineError");
+        }
+	});
+    it('will retry 3 times with ECONNRESET error.', async function () {
 		const line = new MessengerLine({
 			channel_id: 'dummy',
 			channel_secret: 'dummy',


### PR DESCRIPTION
MessengerLine.request()の際、
ECONNRESETやECONNREFUSEDが発生した場合に、最大3回までリトライします。
また、401、429、501エラーが返ってきた場合にも、3回までリトライするようにしてみました。

ちょっと古い記事ですが、axiosでこのエラーが発生すると、
e.codeに'ECONNRESET'や'ECONNREFUSED'が格納される仕様のようです。
（別途、自前のコードで挙動を確認済みです。）
https://github.com/axios/axios/issues/543

 const max_retry = 3;　は、
数値を変更できるようにすると、それはそれで不正な値を入力した場合の対策が必要なため、
現状ではわざと決め打ちにしています。