### PR TITLE
Change to use previous.confirmed in case of modify_previous multiple times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bot-express",
-  "version": "0.9.24",
+  "version": "0.9.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "./module/messenger/*": "./dist/module/messenger/*.js"
   },
   "name": "bot-express",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "private": false,
   "repository": {
     "type": "git",

--- a/src/module/bot.js
+++ b/src/module/bot.js
@@ -776,7 +776,7 @@ class Bot {
      */
     rewind_confirmed(options = {}){
         // If we're in sub parameter and collect first child question, we need to go back to previous parameter.
-        if (this._context._sub_parameter && Object.keys(this._context.confirmed).length === 0) {
+        if (this._context._sub_parameter && this._context.previous.confirmed.length === 0) {
             this.checkout_parent_parameter()
         }
 


### PR DESCRIPTION
sub_parameter内で複数回modify_previousを実行し、parent_paremeterに戻る時にconfirmedにはそのまま回答内容が含まれていたためprevious.confirmedに切り替えた。previous.confirmedはmodify_previousの処理で消している。